### PR TITLE
Fix calendar location.

### DIFF
--- a/daterange_filter/templates/daterange_filter/filter.html
+++ b/daterange_filter/templates/daterange_filter/filter.html
@@ -4,7 +4,8 @@
     .calendarbox, .clockbox {
         /* Make sure the calendar widget popover displays in front of the sidebar */
         z-index: 1100;
-        margin-left: -251px;
+        margin-left: -16em !important;
+        margin-top: 9em !important;
     }
     .datetimeshortcuts {
         /* Hide "|" symbol */


### PR DESCRIPTION
In Django1.6, calendar appears out of screen and you have to do horizontal screen. The attribute margin-left is override. 
I propose to add the '!important' modifier and set the margin top too.