### PR TITLE
fix daterange_filter function:

### DIFF
--- a/daterange_filter/filter.py
+++ b/daterange_filter/filter.py
@@ -151,7 +151,16 @@ class DateRangeFilter(admin.filters.FieldListFilter):
         self.form = self.get_form(request)
 
     def choices(self, cl):
-        return []
+        """
+        Pop the original parameters, and return the date filter & other filter
+        parameters.
+        """
+        
+        cl.params.pop(self.lookup_kwarg_since, None)
+        cl.params.pop(self.lookup_kwarg_upto, None)
+        return ({
+            'get_query': cl.params,
+        }, )
 
     def expected_parameters(self):
         return [self.lookup_kwarg_since, self.lookup_kwarg_upto]

--- a/daterange_filter/templates/daterange_filter/filter.html
+++ b/daterange_filter/templates/daterange_filter/filter.html
@@ -20,11 +20,17 @@
         font-size: 7pt;
     }
 </style>
+{% with choices.0 as i %}
 <form method="GET" action="">
     {{ spec.form.media }}
     {{ spec.form.as_p }}
     <p class="submit-row">
+        {#create hidden inputs to preserve values from other filters and search field#}
+        {% for k, v in i.get_query.items %}
+                <input type="hidden" name="{{ k }}" value="{{ v }}">
+        {% endfor %}    
     <input type="submit" value="{% trans "Search" %}">
     <input type="reset" value="{% trans "Clear" %}">
     </p>
 </form>
+{% endwith %}


### PR DESCRIPTION
In original version, one can't use date range filter with other filter at the same time.
So we update the choices function of DateRangeFilter, and filter.html.
Now user can filter date range with other filters, not just date filter.