### PR TITLE
Fixed calendar icon moving to a new line in Django 1.9

### DIFF
--- a/daterange_filter/templates/daterange_filter/filter.html
+++ b/daterange_filter/templates/daterange_filter/filter.html
@@ -19,6 +19,9 @@
         /* Make text for "Today" a bit smaller so it appears on one line. */
         font-size: 7pt;
     }
+    #changelist-filter a {
+        display: inline;
+    }
 </style>
 <form method="GET" action="">
     {{ spec.form.media }}


### PR DESCRIPTION
It currently looks like this in Django 1.9. This commit fixes that.

![datefilter](https://cloud.githubusercontent.com/assets/930117/14763532/9a917e44-09b1-11e6-80b0-8822e65390f0.png)
