### PR TITLE
Use SplitDateTimeField instead of DateTimeField.

### DIFF
--- a/daterange_filter/filter.py
+++ b/daterange_filter/filter.py
@@ -115,7 +115,7 @@ class DateTimeRangeForm(DateRangeFilterBaseForm):
         field_name = kwargs.pop('field_name')
         super(DateTimeRangeForm, self).__init__(*args, **kwargs)
 
-        self.fields['%s%s__gte' % (FILTER_PREFIX, field_name)] = forms.DateTimeField(
+        self.fields['%s%s__gte' % (FILTER_PREFIX, field_name)] = forms.SplitDateTimeField(
             label='',
             widget=DateRangeFilterAdminSplitDateTime(
                 attrs={'placeholder': _('From date')}
@@ -124,7 +124,7 @@ class DateTimeRangeForm(DateRangeFilterBaseForm):
             required=False
         )
 
-        self.fields['%s%s__lte' % (FILTER_PREFIX, field_name)] = forms.DateTimeField(
+        self.fields['%s%s__lte' % (FILTER_PREFIX, field_name)] = forms.SplitDateTimeField(
             label='',
             widget=DateRangeFilterAdminSplitDateTime(
                 attrs={'placeholder': _('To date')},
@@ -155,7 +155,7 @@ class DateRangeFilter(admin.filters.FieldListFilter):
         Pop the original parameters, and return the date filter & other filter
         parameters.
         """
-        
+
         cl.params.pop(self.lookup_kwarg_since, None)
         cl.params.pop(self.lookup_kwarg_upto, None)
         return ({


### PR DESCRIPTION
Fixes filtering by date and time by using the appropriate form field.