### PR TITLE
Fix queryset for DateRangeFilter when field_path (related field name)…

### DIFF
--- a/daterange_filter/filter.py
+++ b/daterange_filter/filter.py
@@ -6,6 +6,7 @@ Has the filter that allows to filter by a date range.
 
 '''
 import copy
+import re
 import datetime
 import django
 from django import forms
@@ -177,7 +178,7 @@ class DateRangeFilter(admin.filters.FieldListFilter):
             filter_params = clean_input_prefix(dict(filter(lambda x: bool(x[1]), self.form.cleaned_data.items())))
 
             # filter by upto included
-            lookup_upto = self.lookup_kwarg_upto.lstrip(FILTER_PREFIX)
+            lookup_upto = re.sub('^{}'.format(FILTER_PREFIX), '', self.lookup_kwarg_upto)   # Sort of left replace
             if filter_params.get(lookup_upto) is not None:
                 lookup_kwarg_upto_value = filter_params.pop(lookup_upto)
                 filter_params['%s__lt' % self.field_path] = lookup_kwarg_upto_value + datetime.timedelta(days=1)


### PR DESCRIPTION
… starts with a 'd', 'r', 'f', '_'.

Bug due to the use of lstrip(). Replaced by a simple regular expression to delete the 'drf__' filter prefix from the left (sort of left replace).