### PR TITLE
fix bug with incorrect usage of lstrip()

### DIFF
--- a/daterange_filter/filter.py
+++ b/daterange_filter/filter.py
@@ -177,7 +177,7 @@ class DateRangeFilter(admin.filters.FieldListFilter):
             filter_params = clean_input_prefix(dict(filter(lambda x: bool(x[1]), self.form.cleaned_data.items())))
 
             # filter by upto included
-            lookup_upto = self.lookup_kwarg_upto.lstrip(FILTER_PREFIX)
+            lookup_upto = self.lookup_kwarg_upto.split(FILTER_PREFIX)[1]
             if filter_params.get(lookup_upto) is not None:
                 lookup_kwarg_upto_value = filter_params.pop(lookup_upto)
                 filter_params['%s__lt' % self.field_path] = lookup_kwarg_upto_value + datetime.timedelta(days=1)


### PR DESCRIPTION
The intention of the line `lookup_upto = self.lookup_kwarg_upto.lstrip(FILTER_PREFIX)` is
to remove the prefix. But `.lstrip` doesn't work in this way, on the contrary, it removes **all leading characters** contained in the parameter string, **in any order**. 
Which leads to errors.
For example, evaluating of  `'drf__date_of_birth'.lstrip('drf__')` results in `'ate_of_birth'`, which is obviosuly an error.
